### PR TITLE
use https if available / fix Typing / use Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+*.pyc
+workers.json

--- a/preload.py
+++ b/preload.py
@@ -1,3 +1,8 @@
+import os
+from pathlib import Path
+from inspect import getsourcefile
+from os.path import abspath
+
 def preload(parser):
 	parser.add_argument(
 		"--distributed-remotes",
@@ -22,4 +27,12 @@ def preload(parser):
 		"--distributed-debug",
 		help="Enable debug information",
 		action="store_true"
+	)
+	webui_root_path = Path(abspath(getsourcefile(lambda: 0))).parent.parent.parent
+	config_path = webui_root_path.joinpath('distributed-config.json')
+	# add config file
+	parser.add_argument(
+		"--distributed-config",
+		help="config file to load / save, default: distributed-config.json",
+		default=config_path
 	)

--- a/scripts/spartan/UI.py
+++ b/scripts/spartan/UI.py
@@ -108,7 +108,7 @@ class UI:
                     thin_client_cbx = gradio.Checkbox(
                         label='Thin-client mode (experimental)',
                         info="Only generate images using remote workers. There will be no previews when enabled.",
-                        value=self.world.thin_client_mode
+                        value=False
                     )
                     job_timeout = gradio.Number(
                         label='Job timeout', value=self.world.job_timeout,


### PR DESCRIPTION
1. Loads from config file.
The config file can be placed in webui directory as distributed-config.json

`[{"uuid": "worker1", "address": "https://somewhere.example.com", "auth": "username:password"}]`

2. Fix Typing Annotation Issues.

3. use session

4. allow https connections with auth.


Future work : lets just put this in always_on script.
That will let us actually use nested workers concept, which can call other workers recursively, or we can call this script with API.

This may result some infinite recursion problem too, though, but that should be controlled externally.

Another future work : only use script args if worker has matching scripts.

